### PR TITLE
fixed string issue for app.css

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -6,7 +6,7 @@
     'b612', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono:
-    'b612 mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'B612 Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
 }
 

--- a/app/app.css
+++ b/app/app.css
@@ -6,7 +6,8 @@
     'b612', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono:
-    'b612 mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;'
+    'b612 mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }
 
 html,


### PR DESCRIPTION
This PR fixes a string issue with the `app,css` file which caused an error when running via `npm run dev`

Fixes #1 